### PR TITLE
{feature} parse type annotations on @Input()

### DIFF
--- a/src/codeblock/playground/types.rs
+++ b/src/codeblock/playground/types.rs
@@ -94,6 +94,11 @@ impl PlaygroundInputConfig {
 			default_: Some(default_),
 		}
 	}
+
+	#[inline]
+	pub(super) fn type_(self) -> PlaygroundInputType {
+		self.type_
+	}
 }
 
 pub(crate) struct PlaygroundInput {

--- a/test-book/src/sample-2.ts
+++ b/test-book/src/sample-2.ts
@@ -11,7 +11,7 @@ export class AnnounceComponent {
 	 * Person to tell it's working
 	 */
 	@Input()
-	name = 'Bram';
+	name: 'Bram' | 'reader' = 'Bram';
 }
 
 @Component({
@@ -27,12 +27,10 @@ export class ConvinceComponent {
 	@Input()
 	name = 'Bram';
 
-	exclaim = '!';
+	exclaim = '';
 
 	/**
 	 * Number of exclamation points to write!
-	 *
-	 * @input {"type": "number", "default": 1}
 	 */
 	@Input()
 	set numberOfExclamationPoints(value: number) {


### PR DESCRIPTION
If an input is marked explicitly as a string union type, then we can extract the information from that instead of requiring the enumeration be duplicated into an @input object

Fixes #7