### PR TITLE
{feature} support unary expressions in evaluate

### DIFF
--- a/src/codeblock/playground/types.rs
+++ b/src/codeblock/playground/types.rs
@@ -96,8 +96,13 @@ impl PlaygroundInputConfig {
 	}
 
 	#[inline]
-	pub(super) fn type_(self) -> PlaygroundInputType {
+	pub(super) fn get_type(self) -> PlaygroundInputType {
 		self.type_
+	}
+
+	#[inline]
+	pub(super) fn get_default(self) -> Option<Value> {
+		self.default_
 	}
 }
 

--- a/test-book/src/sample-2.ts
+++ b/test-book/src/sample-2.ts
@@ -12,6 +12,9 @@ export class AnnounceComponent {
 	 */
 	@Input()
 	name: 'Bram' | 'reader' = 'reader';
+
+	@Input()
+	notUsed = -1;
 }
 
 @Component({


### PR DESCRIPTION
For some reason negative numbers are parsed
into a unary expression instead of a literal,
so handle those.

Also introduces support for other unary operators
that result in literal types, though they don't
get any default value.

Fixes #11